### PR TITLE
Enable mouse and AI paddle control

### DIFF
--- a/paddle.js
+++ b/paddle.js
@@ -1,5 +1,5 @@
 class Paddle {
-  constructor(x, upKey, downKey, img) {
+  constructor(x, upKey, downKey, img, control = 'keyboard') {
     this.x = x;
     this.y = height / 2;
     this.w = 20;
@@ -8,13 +8,26 @@ class Paddle {
     this.upKey = upKey;
     this.downKey = downKey;
     this.img = img;
+    this.control = control;
   }
 
   update() {
-    if (keyIsDown(this.upKey)) {
-      this.y -= this.speed;
-    } else if (keyIsDown(this.downKey)) {
-      this.y += this.speed;
+    if (this.control === 'mouse') {
+      this.y = mouseY;
+    } else if (this.control === 'ai') {
+      if (typeof ball !== 'undefined') {
+        if (ball.y < this.y - this.speed) {
+          this.y -= this.speed;
+        } else if (ball.y > this.y + this.speed) {
+          this.y += this.speed;
+        }
+      }
+    } else {
+      if (keyIsDown(this.upKey)) {
+        this.y -= this.speed;
+      } else if (keyIsDown(this.downKey)) {
+        this.y += this.speed;
+      }
     }
     this.y = constrain(this.y, this.h / 2, height - this.h / 2);
   }

--- a/sketch.js
+++ b/sketch.js
@@ -22,8 +22,8 @@ function preload() {
 
 function setup() {
   createCanvas(800, 450);
-  leftPaddle = new Paddle(40, 87, 83, paddle1Img); // W and S keys
-  rightPaddle = new Paddle(width - 40, UP_ARROW, DOWN_ARROW, paddle2Img);
+  leftPaddle = new Paddle(40, 87, 83, paddle1Img, 'mouse'); // controlled by mouse
+  rightPaddle = new Paddle(width - 40, UP_ARROW, DOWN_ARROW, paddle2Img, 'ai');
   ball = new Ball(ballImg);
   textAlign(CENTER, CENTER);
   textSize(32);


### PR DESCRIPTION
## Summary
- add `control` option to `Paddle` class
- control left paddle with mouse and right paddle with simple AI

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685aac25f5bc832398ce7f8aa0b9b66d