### PR TITLE
Add round completion with restart

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -3,6 +3,9 @@ let rightPaddle;
 let ball;
 let leftScore = 0;
 let rightScore = 0;
+const winningScore = 4; // points needed to win a round
+let roundOver = false;
+let restartButton;
 
 let bgImg;
 let paddle1Img;
@@ -27,6 +30,10 @@ function setup() {
   ball = new Ball(ballImg);
   textAlign(CENTER, CENTER);
   textSize(32);
+  restartButton = createButton('Reiniciar');
+  restartButton.position(width / 2 - 50, height / 2 + 20);
+  restartButton.mousePressed(restartGame);
+  restartButton.hide();
 }
 
 function draw() {
@@ -36,29 +43,38 @@ function draw() {
     background(0);
   }
 
-  leftPaddle.update();
-  rightPaddle.update();
-  ball.update();
+  if (!roundOver) {
+    leftPaddle.update();
+    rightPaddle.update();
+    ball.update();
 
-  if (ball.checkPaddle(leftPaddle) || ball.checkPaddle(rightPaddle)) {
-    if (hitSound && hitSound.isLoaded()) {
-      hitSound.play();
+    if (ball.checkPaddle(leftPaddle) || ball.checkPaddle(rightPaddle)) {
+      if (hitSound && hitSound.isLoaded()) {
+        hitSound.play();
+      }
     }
-  }
 
-  const out = ball.outOfBounds();
-  if (out) {
-    if (out === 'left') {
-      leftScore++;
-      ball.resetDirection = -1;
-    } else if (out === 'right') {
-      rightScore++;
-      ball.resetDirection = 1;
+    const out = ball.outOfBounds();
+    if (out) {
+      if (out === 'left') {
+        leftScore++;
+        ball.resetDirection = -1;
+      } else if (out === 'right') {
+        rightScore++;
+        ball.resetDirection = 1;
+      }
+      if (scoreSound && scoreSound.isLoaded()) {
+        scoreSound.play();
+      }
+      ball.reset(ball.resetDirection);
+
+      if (leftScore >= winningScore || rightScore >= winningScore) {
+        roundOver = true;
+        ball.vx = 0;
+        ball.vy = 0;
+        restartButton.show();
+      }
     }
-    if (scoreSound && scoreSound.isLoaded()) {
-      scoreSound.play();
-    }
-    ball.reset(ball.resetDirection);
   }
 
   leftPaddle.draw();
@@ -68,4 +84,24 @@ function draw() {
   fill(255);
   text(leftScore, width / 4, 30);
   text(rightScore, (3 * width) / 4, 30);
+
+  if (roundOver) {
+    displayWinner();
+  }
+}
+
+function displayWinner() {
+  const winner = leftScore >= winningScore ? 'Jogador 1 venceu!' : 'Jogador 2 venceu!';
+  textSize(48);
+  fill(255, 215, 0);
+  text(winner, width / 2, height / 2 - 20);
+  textSize(32);
+}
+
+function restartGame() {
+  leftScore = 0;
+  rightScore = 0;
+  roundOver = false;
+  ball.reset(random() < 0.5 ? -1 : 1);
+  restartButton.hide();
 }


### PR DESCRIPTION
## Summary
- add `winningScore` constant for controlling when a round ends
- display button to restart when someone reaches 4 points
- freeze gameplay and show winning message after a round

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aaeb92b188323b82cc68a324471cb